### PR TITLE
FMT: Sanitize input filenames to make cl-safe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 
 # Uses Ubuntu 16.04 LTS
-FROM flywheel/hcp-base:0.2.0_4.0.1
+FROM flywheel/hcp-base:1.0.1_4.0.1
 
 LABEL maintainer="Flywheel <support@flywheel.io>"
 
@@ -20,7 +20,7 @@ COPY neurodebian_pgpkey.txt /tmp/
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl && \
-    curl -sSL http://neuro.debian.net/lists/trusty.us-ca.full >> /etc/apt/sources.list.d/neurodebian.sources.list && \
+    curl -sSL http://neurodebian.ovgu.de/lists/trusty.us-ca.full >> /etc/apt/sources.list.d/neurodebian.sources.list && \
     apt-key add /tmp/neurodebian_pgpkey.txt && \
     apt-get update && \
     apt-get install -y fsl-core=5.0.9-5~nd14.04+1 && \

--- a/manifest.json
+++ b/manifest.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Washington-University/Pipelines",
     "source": "https://github.com/flywheel-apps/hcp-func",
     "cite": "Glasser M. F., Sotiropoulos S. N., Wilson J. A., Coalson T. S., Fischl B., Andersson J. L., … Consortium, W. U.-M. H. (2013). The minimal preprocessing pipelines for the Human Connectome Project. NeuroImage, 80, 105–124.",
-    "version": "0.2.0_4.0.1",
+    "version": "1.0.1_4.0.1",
     "custom": {
-        "docker-image": "flywheel/hcp-func:0.2.0_4.0.1",
+        "docker-image": "flywheel/hcp-func:1.0.1_4.0.1",
         "gear-builder": {
             "category": "analysis",
-            "image": "flywheel/hcp-func:0.2.0_4.0.1"
+            "image": "flywheel/hcp-func:1.0.1_4.0.1"
         },
         "flywheel": {
             "suite": "Human Connectome Project"

--- a/utils/args/GenericfMRIVolumeProcessingPipeline.py
+++ b/utils/args/GenericfMRIVolumeProcessingPipeline.py
@@ -10,6 +10,7 @@ import re
 from collections import OrderedDict
 
 from tr import tr
+from utils.gear_preliminaries import create_sanitized_filepath
 
 from .common import build_command_list, exec_command
 
@@ -56,7 +57,9 @@ def build(context):
 
     # TODO: confirm parameters match fMRITimeSeries?
     if "fMRIScout" in inputs.keys():
-        params["fmriscout"] = context.get_input_path("fMRIScout")
+        params["fmriscout"] = create_sanitized_filepath(
+            context.get_input_path("fMRIScout")
+        )
 
     # Read necessary acquisition params from fMRI
     obj = inputs["fMRITimeSeries"]["object"]
@@ -80,8 +83,12 @@ def build(context):
     if ("SiemensGREMagnitude" in inputs.keys()) and (
         "SiemensGREPhase" in inputs.keys()
     ):
-        params["fmapmag"] = context.get_input_path("SiemensGREMagnitude")
-        params["fmapphase"] = context.get_input_path("SiemensGREPhase")
+        params["fmapmag"] = create_sanitized_filepath(
+            context.get_input_path("SiemensGREMagnitude")
+        )
+        params["fmapphase"] = create_sanitized_filepath(
+            context.get_input_path("SiemensGREPhase")
+        )
         params["dcmethod"] = "SiemensFieldMap"
         params["topupconfig"] = "NONE"
 
@@ -97,8 +104,12 @@ def build(context):
         "SpinEchoPositive" in inputs.keys()
     ):
         params["dcmethod"] = "TOPUP"
-        SpinEchoPhase1 = context.get_input_path("SpinEchoPositive")
-        SpinEchoPhase2 = context.get_input_path("SpinEchoNegative")
+        SpinEchoPhase1 = create_sanitized_filepath(
+            context.get_input_path("SpinEchoPositive")
+        )
+        SpinEchoPhase2 = create_sanitized_filepath(
+            context.get_input_path("SpinEchoNegative")
+        )
         # Topup config if using TOPUP, set to NONE if using regular FIELDMAP
         params["topupconfig"] = environ["HCPPIPEDIR_Config"] + "/b02b0.cnf"
         if (
@@ -149,7 +160,9 @@ def build(context):
         raise Exception("Cannot currently handle GeneralElectricFieldmap!")
 
     if "GradientCoeff" in inputs.keys():
-        params["gdcoeffs"] = context.get_input_path("GradientCoeff")
+        params["gdcoeffs"] = create_sanitized_filepath(
+            context.get_input_path("GradientCoeff")
+        )
 
     params["printcom"] = " "
 

--- a/utils/args/GenericfMRIVolumeProcessingPipeline.py
+++ b/utils/args/GenericfMRIVolumeProcessingPipeline.py
@@ -2,6 +2,7 @@
 Builds, validates, and excecutes parameters for the HCP script 
 /opt/HCP-Pipelines/fMRIVolume/GenericfMRIVolumeProcessingPipeline.sh
 part of the hcp-func gear
+NOTE: the `utils.gear_preliminaries` module is in the `hcp-base` code
 """
 import logging
 import os


### PR DESCRIPTION
* FIX: Change to Dockerfile to reference unexpired trusty dependency
* FIX: Sanitize input filenames to make them command-line safe.
* Note: The referenced function `create_sanitized_filepath` is in [`hcp-base`](https://github.com/flywheel-apps/hcp-base/blob/master/utils/gear_preliminaries.py#L320) and shared across the HCP-SUITE. 